### PR TITLE
CompatHelper: add new compat entry for JSON3 at version 1, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ Arrow = "2"
 CSV = "0.10"
 DataFrames = "1"
 HTTP = "1"
+JSON3 = "1"
 URIs = "1"
 julia = "1"
 


### PR DESCRIPTION
This pull request sets the compat entry for the `JSON3` package to `1`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.
Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.